### PR TITLE
feat(backlog): disable auto-browser and remote operations for Claude Code compatibility

### DIFF
--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -5,9 +5,9 @@ labels: []
 milestones: []
 date_format: yyyy-mm-dd
 max_column_width: 20
-auto_open_browser: true
+auto_open_browser: false
 default_port: 6420
-remote_operations: true
+remote_operations: false
 auto_commit: false
 bypass_git_hooks: false
 check_active_branches: true


### PR DESCRIPTION
## Summary
- Set auto_open_browser to false for Claude Code compatibility
- Set remote_operations to false for local-only backlog management

## Changes
-  - Prevents unexpected browser launches during Claude Code sessions
-  - Ensures backlog operations work reliably in local development

## Benefits
- Improves performance in automated environments
- Reduces interruptions during development workflow
- Better compatibility with Claude Code's headless operation mode

## Testing
- Verified backlog commands work correctly with new settings
- No breaking changes to existing backlog functionality